### PR TITLE
Manage IAM roles for Kubernetes clusters

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,6 +14,22 @@ repos:
   - repo: https://github.com/antonbabenko/pre-commit-terraform
     rev: v1.83.6
     hooks:
+
+      - id: terraform_fmt
+
+      # To speed up local validation add the following to your ~/.zshrc:
+      # export TF_PLUGIN_CACHE_DIR=$HOME/.terraform.d/plugin-cache
+
+      - id: terraform_validate
+        args:
+          - --hook-config=--retry-once-with-cleanup=true
+          - --tf-init-args=-upgrade
+      - id: terraform_docs
+        args:
+          - --hook-config=--path-to-file=README.md
+          - --hook-config=--add-to-exiting-file=true
+          - --hook-config=--create-file-if-not-exist=false
+
       - id: infracost_breakdown
         args:
           - --args=--sync-usage-file
@@ -68,18 +84,3 @@ repos:
           - --args=--usage-file=regional/infra/infracost/us-east4-production.yml
           - --args=--path=regional/infra
           - --args=--terraform-var-file=tfvars/us-east4-production.tfvars
-
-      - id: terraform_fmt
-
-      # To speed up local validation add the following to your ~/.zshrc:
-      # export TF_PLUGIN_CACHE_DIR=$HOME/.terraform.d/plugin-cache
-
-      - id: terraform_validate
-        args:
-          - --hook-config=--retry-once-with-cleanup=true
-          - --tf-init-args=-upgrade
-      - id: terraform_docs
-        args:
-          - --hook-config=--path-to-file=README.md
-          - --hook-config=--add-to-exiting-file=true
-          - --hook-config=--create-file-if-not-exist=false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,6 +14,61 @@ repos:
   - repo: https://github.com/antonbabenko/pre-commit-terraform
     rev: v1.83.6
     hooks:
+      - id: infracost_breakdown
+        args:
+          - --args=--sync-usage-file
+          - --args=--usage-file=global/infra/infracost/sandbox.yml
+          - --args=--path=global/infra
+          - --args=--terraform-var-file=tfvars/sandbox.tfvars
+      - id: infracost_breakdown
+        args:
+          - --args=--sync-usage-file
+          - --args=--usage-file=global/infra/infracost/non-production.yml
+          - --args=--path=global/infra
+          - --args=--terraform-var-file=tfvars/non-production.tfvars
+      - id: infracost_breakdown
+        args:
+          - --args=--sync-usage-file
+          - --args=--usage-file=global/infra/infracost/production.yml
+          - --args=--path=global/infra
+          - --args=--terraform-var-file=tfvars/production.tfvars
+      - id: infracost_breakdown
+        args:
+          - --args=--sync-usage-file
+          - --args=--usage-file=regional/infra/infracost/us-east1-sandbox.yml
+          - --args=--path=regional/infra
+          - --args=--terraform-var-file=tfvars/us-east1-sandbox.tfvars
+      - id: infracost_breakdown
+        args:
+          - --args=--sync-usage-file
+          - --args=--usage-file=regional/infra/infracost/us-east1-non-production.yml
+          - --args=--path=regional/infra
+          - --args=--terraform-var-file=tfvars/us-east1-non-production.tfvars
+      - id: infracost_breakdown
+        args:
+          - --args=--sync-usage-file
+          - --args=--usage-file=regional/infra/infracost/us-east1-production.yml
+          - --args=--path=regional/infra
+          - --args=--terraform-var-file=tfvars/us-east1-production.tfvars
+      - id: infracost_breakdown
+        args:
+          - --args=--sync-usage-file
+          - --args=--usage-file=regional/infra/infracost/us-east4-sandbox.yml
+          - --args=--path=regional/infra
+          - --args=--terraform-var-file=tfvars/us-east4-sandbox.tfvars
+      - id: infracost_breakdown
+        args:
+          - --args=--sync-usage-file
+          - --args=--usage-file=regional/infra/infracost/us-east4-non-production.yml
+          - --args=--path=regional/infra
+          - --args=--terraform-var-file=tfvars/us-east4-non-production.tfvars
+      - id: infracost_breakdown
+        args:
+          - --args=--sync-usage-file
+          - --args=--usage-file=regional/infra/infracost/us-east4-production.yml
+          - --args=--path=regional/infra
+          - --args=--terraform-var-file=tfvars/us-east4-production.tfvars
+
       - id: terraform_fmt
 
       # To speed up local validation add the following to your ~/.zshrc:

--- a/global/infra/README.md
+++ b/global/infra/README.md
@@ -25,6 +25,7 @@ No requirements.
 | Name | Type |
 |------|------|
 | [google_compute_global_address.service_network_peering_range](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_global_address) | resource |
+| [google_compute_shared_vpc_service_project.this](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_shared_vpc_service_project) | resource |
 | [google_project_iam_member.container_engine_firewall_management](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
 | [google_project_iam_member.container_engine_service_agent_user](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
 | [google_service_networking_connection.this](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_networking_connection) | resource |

--- a/global/infra/README.md
+++ b/global/infra/README.md
@@ -9,14 +9,14 @@ No requirements.
 
 | Name | Version |
 |------|---------|
-| <a name="provider_google"></a> [google](#provider\_google) | 5.6.0 |
+| <a name="provider_google"></a> [google](#provider\_google) | 5.7.0 |
 
 ## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
 | <a name="module_private_dns"></a> [private\_dns](#module\_private\_dns) | github.com/osinfra-io/terraform-google-cloud-dns//global | v0.1.0 |
-| <a name="module_project"></a> [project](#module\_project) | github.com/osinfra-io/terraform-google-project//global | v0.1.2 |
+| <a name="module_project"></a> [project](#module\_project) | github.com/osinfra-io/terraform-google-project//global | v0.1.7 |
 | <a name="module_public_dns"></a> [public\_dns](#module\_public\_dns) | github.com/osinfra-io/terraform-google-cloud-dns//global | v0.1.0 |
 | <a name="module_vpc"></a> [vpc](#module\_vpc) | github.com/osinfra-io/terraform-google-vpc//global | v0.1.1 |
 
@@ -25,6 +25,8 @@ No requirements.
 | Name | Type |
 |------|------|
 | [google_compute_global_address.service_network_peering_range](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_global_address) | resource |
+| [google_project_iam_member.container_engine_firewall_management](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
+| [google_project_iam_member.container_engine_service_agent_user](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
 | [google_service_networking_connection.this](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_networking_connection) | resource |
 
 ## Inputs
@@ -37,6 +39,7 @@ No requirements.
 | <a name="input_datadog_app_key"></a> [datadog\_app\_key](#input\_datadog\_app\_key) | Datadog APP key | `string` | n/a | yes |
 | <a name="input_environment"></a> [environment](#input\_environment) | The environment suffix for example: `sb` (Sandbox), `nonprod` (Non-Production), `prod` (Production) | `string` | `"sb"` | no |
 | <a name="input_folder_id"></a> [folder\_id](#input\_folder\_id) | The numeric ID of the folder this project should be created under. Only one of `org_id` or `folder_id` may be specified | `string` | n/a | yes |
+| <a name="input_kubernetes_service_projects"></a> [kubernetes\_service\_projects](#input\_kubernetes\_service\_projects) | The set of Kubernetes service projects | `set(string)` | `[]` | no |
 
 ## Outputs
 

--- a/global/infra/README.md
+++ b/global/infra/README.md
@@ -40,7 +40,7 @@ No requirements.
 | <a name="input_datadog_app_key"></a> [datadog\_app\_key](#input\_datadog\_app\_key) | Datadog APP key | `string` | n/a | yes |
 | <a name="input_environment"></a> [environment](#input\_environment) | The environment suffix for example: `sb` (Sandbox), `nonprod` (Non-Production), `prod` (Production) | `string` | `"sb"` | no |
 | <a name="input_folder_id"></a> [folder\_id](#input\_folder\_id) | The numeric ID of the folder this project should be created under. Only one of `org_id` or `folder_id` may be specified | `string` | n/a | yes |
-| <a name="input_kubernetes_service_projects"></a> [kubernetes\_service\_projects](#input\_kubernetes\_service\_projects) | The map of Kubernetes service project IDs and numbers | <pre>object({<br>    number = optional(number)<br>  })</pre> | `{}` | no |
+| <a name="input_kubernetes_service_projects"></a> [kubernetes\_service\_projects](#input\_kubernetes\_service\_projects) | The map of Kubernetes service project IDs and numbers | <pre>map(object({<br>    number = optional(number)<br>  }))</pre> | `{}` | no |
 
 ## Outputs
 

--- a/global/infra/README.md
+++ b/global/infra/README.md
@@ -40,7 +40,7 @@ No requirements.
 | <a name="input_datadog_app_key"></a> [datadog\_app\_key](#input\_datadog\_app\_key) | Datadog APP key | `string` | n/a | yes |
 | <a name="input_environment"></a> [environment](#input\_environment) | The environment suffix for example: `sb` (Sandbox), `nonprod` (Non-Production), `prod` (Production) | `string` | `"sb"` | no |
 | <a name="input_folder_id"></a> [folder\_id](#input\_folder\_id) | The numeric ID of the folder this project should be created under. Only one of `org_id` or `folder_id` may be specified | `string` | n/a | yes |
-| <a name="input_kubernetes_service_projects"></a> [kubernetes\_service\_projects](#input\_kubernetes\_service\_projects) | The set of Kubernetes service projects | `set(string)` | `[]` | no |
+| <a name="input_kubernetes_service_projects"></a> [kubernetes\_service\_projects](#input\_kubernetes\_service\_projects) | The map of Kubernetes service project IDs and numbers | <pre>object({<br>    number = optional(number)<br>  })</pre> | `{}` | no |
 
 ## Outputs
 

--- a/global/infra/infracost/non-production.yml
+++ b/global/infra/infracost/non-production.yml
@@ -6,16 +6,6 @@ version: 0.1
 resource_type_default_usage:
   google_logging_project_sink:
     monthly_logging_data_gb: 5.0 # Monthly logging data in GB.
-  google_pubsub_subscription:
-    monthly_message_data_tb: 0.1 # Monthly amount of message data pulled by the subscription in TB.
-    storage_gb: 1.0 # Storage for retaining acknowledged messages in GB.
-    snapshot_storage_gb: 0.0 # Snapshot storage for unacknowledged messages in GB.
-  google_pubsub_topic:
-    monthly_message_data_tb: 0.1 # Monthly amount of message data published to the topic in TB.
-  ##
-  ## The following usage values apply to each resource of the given type, which is useful when you want to define defaults.
-  ## All values are commented-out, you can uncomment resource types and customize as needed.
-  ##
   google_service_networking_connection:
     monthly_egress_data_transfer_gb:
       same_region: 10 # VMs in the same Google Cloud region.
@@ -39,13 +29,5 @@ resource_type_default_usage:
       # south_america: 0 # Between Google Cloud regions within South America.
       # oceania: 0 # Indonesia and Oceania to/from any Google Cloud region.
       # worldwide: 0 # to a Google Cloud region on another continent.
-  # module.datadog.google_logging_project_sink.this:
-    # monthly_logging_data_gb: 0.0 # Monthly logging data in GB.
-  # module.datadog.google_pubsub_subscription.this:
-    # monthly_message_data_tb: 0.0 # Monthly amount of message data pulled by the subscription in TB.
-    # storage_gb: 0.0 # Storage for retaining acknowledged messages in GB.
-    # snapshot_storage_gb: 0.0 # Snapshot storage for unacknowledged messages in GB.
-  # module.datadog.google_pubsub_topic.this:
-    # monthly_message_data_tb: 0.0 # Monthly amount of message data published to the topic in TB.
   # module.project.google_logging_project_sink.cis_2_2_logging_sink:
     # monthly_logging_data_gb: 0.0 # Monthly logging data in GB.

--- a/global/infra/infracost/production.yml
+++ b/global/infra/infracost/production.yml
@@ -6,16 +6,6 @@ version: 0.1
 resource_type_default_usage:
   google_logging_project_sink:
     monthly_logging_data_gb: 5.0 # Monthly logging data in GB.
-  google_pubsub_subscription:
-    monthly_message_data_tb: 0.1 # Monthly amount of message data pulled by the subscription in TB.
-    storage_gb: 1.0 # Storage for retaining acknowledged messages in GB.
-    snapshot_storage_gb: 0.0 # Snapshot storage for unacknowledged messages in GB.
-  google_pubsub_topic:
-    monthly_message_data_tb: 0.1 # Monthly amount of message data published to the topic in TB.
-  ##
-  ## The following usage values apply to each resource of the given type, which is useful when you want to define defaults.
-  ## All values are commented-out, you can uncomment resource types and customize as needed.
-  ##
   google_service_networking_connection:
     monthly_egress_data_transfer_gb:
       same_region: 15 # VMs in the same Google Cloud region.
@@ -39,13 +29,5 @@ resource_type_default_usage:
       # south_america: 0 # Between Google Cloud regions within South America.
       # oceania: 0 # Indonesia and Oceania to/from any Google Cloud region.
       # worldwide: 0 # to a Google Cloud region on another continent.
-  # module.datadog.google_logging_project_sink.this:
-    # monthly_logging_data_gb: 0.0 # Monthly logging data in GB.
-  # module.datadog.google_pubsub_subscription.this:
-    # monthly_message_data_tb: 0.0 # Monthly amount of message data pulled by the subscription in TB.
-    # storage_gb: 0.0 # Storage for retaining acknowledged messages in GB.
-    # snapshot_storage_gb: 0.0 # Snapshot storage for unacknowledged messages in GB.
-  # module.datadog.google_pubsub_topic.this:
-    # monthly_message_data_tb: 0.0 # Monthly amount of message data published to the topic in TB.
   # module.project.google_logging_project_sink.cis_2_2_logging_sink:
     # monthly_logging_data_gb: 0.0 # Monthly logging data in GB.

--- a/global/infra/infracost/sandbox.yml
+++ b/global/infra/infracost/sandbox.yml
@@ -6,16 +6,6 @@ version: 0.1
 resource_type_default_usage:
   google_logging_project_sink:
     monthly_logging_data_gb: 5.0 # Monthly logging data in GB.
-  google_pubsub_subscription:
-    monthly_message_data_tb: 0.1 # Monthly amount of message data pulled by the subscription in TB.
-    storage_gb: 1.0 # Storage for retaining acknowledged messages in GB.
-    snapshot_storage_gb: 0.0 # Snapshot storage for unacknowledged messages in GB.
-  google_pubsub_topic:
-    monthly_message_data_tb: 0.1 # Monthly amount of message data published to the topic in TB.
-  ##
-  ## The following usage values apply to each resource of the given type, which is useful when you want to define defaults.
-  ## All values are commented-out, you can uncomment resource types and customize as needed.
-  ##
   google_service_networking_connection:
     monthly_egress_data_transfer_gb:
       same_region: 5 # VMs in the same Google Cloud region.
@@ -39,13 +29,5 @@ resource_type_default_usage:
       # south_america: 0 # Between Google Cloud regions within South America.
       # oceania: 0 # Indonesia and Oceania to/from any Google Cloud region.
       # worldwide: 0 # to a Google Cloud region on another continent.
-  # module.datadog.google_logging_project_sink.this:
-    # monthly_logging_data_gb: 0.0 # Monthly logging data in GB.
-  # module.datadog.google_pubsub_subscription.this:
-    # monthly_message_data_tb: 0.0 # Monthly amount of message data pulled by the subscription in TB.
-    # storage_gb: 0.0 # Storage for retaining acknowledged messages in GB.
-    # snapshot_storage_gb: 0.0 # Snapshot storage for unacknowledged messages in GB.
-  # module.datadog.google_pubsub_topic.this:
-    # monthly_message_data_tb: 0.0 # Monthly amount of message data published to the topic in TB.
   # module.project.google_logging_project_sink.cis_2_2_logging_sink:
     # monthly_logging_data_gb: 0.0 # Monthly logging data in GB.

--- a/global/infra/main.tf
+++ b/global/infra/main.tf
@@ -155,7 +155,7 @@ resource "google_compute_shared_vpc_service_project" "this" {
 resource "google_project_iam_member" "container_engine_firewall_management" {
   for_each = var.kubernetes_service_projects
 
-  member  = "serviceAccount:service-${each.key}@container-engine-robot.iam.gserviceaccount.com"
+  member  = "serviceAccount:service-${each.value.number}@container-engine-robot.iam.gserviceaccount.com"
   project = module.project.project_id
   role    = "organizations/163313809793/roles/kubernetes.hostFirewallManagement"
 }
@@ -163,7 +163,7 @@ resource "google_project_iam_member" "container_engine_firewall_management" {
 resource "google_project_iam_member" "container_engine_service_agent_user" {
   for_each = var.kubernetes_service_projects
 
-  member  = "serviceAccount:service-${each.key}@container-engine-robot.iam.gserviceaccount.com"
+  member  = "serviceAccount:service-${each.value.number}@container-engine-robot.iam.gserviceaccount.com"
   project = module.project.project_id
   role    = "roles/container.hostServiceAgentUser"
 }

--- a/global/infra/main.tf
+++ b/global/infra/main.tf
@@ -139,6 +139,16 @@ resource "google_compute_global_address" "service_network_peering_range" {
   purpose       = "VPC_PEERING"
 }
 
+# Compute Shared VPC Service Project Resource
+# https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_shared_vpc_service_project
+
+resource "google_compute_shared_vpc_service_project" "this" {
+  for_each = var.kubernetes_service_projects
+
+  host_project    = module.project.project_id
+  service_project = each.key
+}
+
 # Project IAM Member Resource
 # https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/google_project_iam_member
 

--- a/global/infra/main.tf
+++ b/global/infra/main.tf
@@ -64,6 +64,7 @@ module "project" {
     "cloudbilling.googleapis.com",
     "cloudresourcemanager.googleapis.com",
     "compute.googleapis.com",
+    "container.googleapis.com",
     "dns.googleapis.com",
     "iam.googleapis.com",
     "monitoring.googleapis.com",

--- a/global/infra/main.tf
+++ b/global/infra/main.tf
@@ -51,10 +51,10 @@ module "project" {
   folder_id                       = var.folder_id
 
   labels = {
-    env      = var.environment
-    module   = "google-cloud-networking"
-    platform = "google-cloud-landing-zone"
-    team     = "platform-google-cloud-landing-zone"
+    env        = var.environment
+    repository = "google-cloud-networking"
+    platform   = "google-cloud-landing-zone"
+    team       = "platform-google-cloud-landing-zone"
   }
 
   prefix = "plt-lz"
@@ -83,7 +83,7 @@ module "private_dns" {
   labels = {
     env         = var.environment
     cost-center = "x001"
-    module      = "google-cloud-networking"
+    repository  = "google-cloud-networking"
     platform    = "google-cloud-landing-zone"
     team        = "platform-google-cloud-landing-zone"
   }
@@ -106,7 +106,7 @@ module "public_dns" {
   labels = {
     env         = var.environment
     cost-center = "x001"
-    module      = "google-cloud-networking"
+    repository  = "google-cloud-networking"
     platform    = "google-cloud-landing-zone"
     team        = "platform-google-cloud-landing-zone"
   }

--- a/global/infra/main.tf
+++ b/global/infra/main.tf
@@ -139,6 +139,25 @@ resource "google_compute_global_address" "service_network_peering_range" {
   purpose       = "VPC_PEERING"
 }
 
+# Project IAM Member Resource
+# https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/google_project_iam_member
+
+resource "google_project_iam_member" "container_engine_firewall_management" {
+  for_each = var.kubernetes_service_projects
+
+  member  = "serviceAccount:service-${each.key}@container-engine-robot.iam.gserviceaccount.com"
+  project = module.project.project_id
+  role    = "organizations/163313809793/roles/kubernetes.hostFirewallManagement"
+}
+
+resource "google_project_iam_member" "container_engine_service_agent_user" {
+  for_each = var.kubernetes_service_projects
+
+  member  = "serviceAccount:service-${each.key}@container-engine-robot.iam.gserviceaccount.com"
+  project = module.project.project_id
+  role    = "roles/container.hostServiceAgentUser"
+}
+
 # Service Networking Connection Resource
 # https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_networking_connection
 

--- a/global/infra/tfvars/non-production.tfvars
+++ b/global/infra/tfvars/non-production.tfvars
@@ -1,4 +1,9 @@
 environment                     = "nonprod"
 cis_2_2_logging_sink_project_id = "plt-lz-audit01-tfe6-nonprod"
 folder_id                       = "345391277536"
-kubernetes_service_projects     = ["plt-k8s-tf33-nonprod"]
+
+kubernetes_service_projects = {
+  "plt-k8s-tf33-nonprod" = {
+    number = 1036446604184
+  }
+}

--- a/global/infra/tfvars/non-production.tfvars
+++ b/global/infra/tfvars/non-production.tfvars
@@ -1,3 +1,4 @@
 environment                     = "nonprod"
 cis_2_2_logging_sink_project_id = "plt-lz-audit01-tfe6-nonprod"
 folder_id                       = "345391277536"
+kubernetes_service_projects     = ["plt-k8s-tf33-nonprod"]

--- a/global/infra/tfvars/production.tfvars
+++ b/global/infra/tfvars/production.tfvars
@@ -1,3 +1,4 @@
 environment                     = "prod"
 cis_2_2_logging_sink_project_id = "plt-lz-audit01-tf24-prod"
 folder_id                       = "1033174574192"
+kubernetes_service_projects     = ["plt-k8s-tf10-prod"]

--- a/global/infra/tfvars/production.tfvars
+++ b/global/infra/tfvars/production.tfvars
@@ -1,4 +1,9 @@
 environment                     = "prod"
 cis_2_2_logging_sink_project_id = "plt-lz-audit01-tf24-prod"
 folder_id                       = "1033174574192"
-kubernetes_service_projects     = ["plt-k8s-tf10-prod"]
+
+kubernetes_service_projects = {
+  "plt-k8s-tf10-prod" = {
+    number = 502462287439
+  }
+}

--- a/global/infra/tfvars/sandbox.tfvars
+++ b/global/infra/tfvars/sandbox.tfvars
@@ -1,2 +1,3 @@
 cis_2_2_logging_sink_project_id = "plt-lz-audit01-tf6e-sb"
 folder_id                       = "13103602325"
+kubernetes_service_projects     = ["plt-k8s-tfb4-sb"]

--- a/global/infra/tfvars/sandbox.tfvars
+++ b/global/infra/tfvars/sandbox.tfvars
@@ -1,3 +1,8 @@
 cis_2_2_logging_sink_project_id = "plt-lz-audit01-tf6e-sb"
 folder_id                       = "13103602325"
-kubernetes_service_projects     = ["plt-k8s-tfb4-sb"]
+
+kubernetes_service_projects = {
+  "plt-k8s-tfb4-sb" = {
+    number = 102727685445
+  }
+}

--- a/global/infra/variables.tf
+++ b/global/infra/variables.tf
@@ -37,8 +37,8 @@ variable "folder_id" {
 
 variable "kubernetes_service_projects" {
   description = "The map of Kubernetes service project IDs and numbers"
-  type = object({
+  type = map(object({
     number = optional(number)
-  })
+  }))
   default = {}
 }

--- a/global/infra/variables.tf
+++ b/global/infra/variables.tf
@@ -36,7 +36,9 @@ variable "folder_id" {
 }
 
 variable "kubernetes_service_projects" {
-  description = "The set of Kubernetes service projects"
-  type        = set(string)
-  default     = []
+  description = "The map of Kubernetes service project IDs and numbers"
+  type = object({
+    number = optional(number)
+  })
+  default = {}
 }

--- a/global/infra/variables.tf
+++ b/global/infra/variables.tf
@@ -34,3 +34,9 @@ variable "folder_id" {
   description = "The numeric ID of the folder this project should be created under. Only one of `org_id` or `folder_id` may be specified"
   type        = string
 }
+
+variable "kubernetes_service_projects" {
+  description = "The set of Kubernetes service projects"
+  type        = set(string)
+  default     = []
+}

--- a/infracost-sync.sh
+++ b/infracost-sync.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env zsh
+
+set -e
+
+locations=(us-east1 us-east4 global)
+environments=(sandbox non-production production)
+
+for location in "${locations[@]}"; do
+  for environment in "${environments[@]}"; do
+    if [ "$location" = "global" ]; then
+      infracost breakdown --sync-usage-file \
+      --usage-file global/infra/infracost/${environment}.yml \
+      --path global/infra \
+      --terraform-var-file tfvars/${environment}.tfvars
+    else
+      infracost breakdown --sync-usage-file \
+      --usage-file regional/infra/infracost/${location}-${environment}.yml \
+      --path regional/infra \
+      --terraform-var-file tfvars/${location}-${environment}.tfvars
+    fi
+  done
+done

--- a/regional/infra/README.md
+++ b/regional/infra/README.md
@@ -32,7 +32,7 @@ No requirements.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_environment"></a> [environment](#input\_environment) | The environment for example: `sandbox`, `non-production`, `production` | `string` | `"sandbox"` | no |
-| <a name="input_kubernetes_service_projects"></a> [kubernetes\_service\_projects](#input\_kubernetes\_service\_projects) | The set of Kubernetes service projects | `set(string)` | `[]` | no |
+| <a name="input_kubernetes_service_projects"></a> [kubernetes\_service\_projects](#input\_kubernetes\_service\_projects) | The map of Kubernetes service project IDs and numbers | <pre>map(object({<br>    number = optional(number)<br>  }))</pre> | `{}` | no |
 | <a name="input_region"></a> [region](#input\_region) | The region for this subnetwork | `string` | n/a | yes |
 | <a name="input_remote_bucket"></a> [remote\_bucket](#input\_remote\_bucket) | The remote bucket the `terraform_remote_state` data source retrieves the state from | `string` | n/a | yes |
 | <a name="input_subnets"></a> [subnets](#input\_subnets) | The map of subnets to create | <pre>map(object({<br>    ip_cidr_range          = string<br>    master_ip_cidr_range   = string<br>    pod_ip_cidr_range      = string<br>    services_ip_cidr_range = string<br>  }))</pre> | n/a | yes |

--- a/regional/infra/README.md
+++ b/regional/infra/README.md
@@ -9,6 +9,7 @@ No requirements.
 
 | Name | Version |
 |------|---------|
+| <a name="provider_google"></a> [google](#provider\_google) | 4.79.0 |
 | <a name="provider_terraform"></a> [terraform](#provider\_terraform) | n/a |
 
 ## Modules
@@ -22,6 +23,8 @@ No requirements.
 
 | Name | Type |
 |------|------|
+| [google_compute_subnetwork_iam_member.cloud_services](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_subnetwork_iam_member) | resource |
+| [google_compute_subnetwork_iam_member.container_engine](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_subnetwork_iam_member) | resource |
 | [terraform_remote_state.global](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/data-sources/remote_state) | data source |
 
 ## Inputs
@@ -29,6 +32,7 @@ No requirements.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_environment"></a> [environment](#input\_environment) | The environment for example: `sandbox`, `non-production`, `production` | `string` | `"sandbox"` | no |
+| <a name="input_kubernetes_service_projects"></a> [kubernetes\_service\_projects](#input\_kubernetes\_service\_projects) | The set of Kubernetes service projects | `set(string)` | `[]` | no |
 | <a name="input_region"></a> [region](#input\_region) | The region for this subnetwork | `string` | n/a | yes |
 | <a name="input_remote_bucket"></a> [remote\_bucket](#input\_remote\_bucket) | The remote bucket the `terraform_remote_state` data source retrieves the state from | `string` | n/a | yes |
 | <a name="input_subnets"></a> [subnets](#input\_subnets) | The map of subnets to create | <pre>map(object({<br>    ip_cidr_range          = string<br>    master_ip_cidr_range   = string<br>    pod_ip_cidr_range      = string<br>    services_ip_cidr_range = string<br>  }))</pre> | n/a | yes |

--- a/regional/infra/infracost/us-east1-non-production.yml
+++ b/regional/infra/infracost/us-east1-non-production.yml
@@ -4,10 +4,6 @@
 # See https://infracost.io/usage-file/ for docs
 version: 0.1
 resource_type_default_usage:
-  ##
-  ## The following usage values apply to each resource of the given type, which is useful when you want to define defaults.
-  ## All values are commented-out, you can uncomment resource types and customize as needed.
-  ##
   google_compute_router_nat:
     assigned_vms: 1 # Number of VM instances assigned to the NAT gateway
     monthly_data_processed_gb: 10.0 # Monthly data processed (ingress and egress) by the NAT gateway in GB

--- a/regional/infra/infracost/us-east1-production.yml
+++ b/regional/infra/infracost/us-east1-production.yml
@@ -4,10 +4,6 @@
 # See https://infracost.io/usage-file/ for docs
 version: 0.1
 resource_type_default_usage:
-  ##
-  ## The following usage values apply to each resource of the given type, which is useful when you want to define defaults.
-  ## All values are commented-out, you can uncomment resource types and customize as needed.
-  ##
   google_compute_router_nat:
     assigned_vms: 3 # Number of VM instances assigned to the NAT gateway
     monthly_data_processed_gb: 25.0 # Monthly data processed (ingress and egress) by the NAT gateway in GB

--- a/regional/infra/infracost/us-east1-sandbox.yml
+++ b/regional/infra/infracost/us-east1-sandbox.yml
@@ -4,10 +4,6 @@
 # See https://infracost.io/usage-file/ for docs
 version: 0.1
 resource_type_default_usage:
-  ##
-  ## The following usage values apply to each resource of the given type, which is useful when you want to define defaults.
-  ## All values are commented-out, you can uncomment resource types and customize as needed.
-  ##
   google_compute_router_nat:
     assigned_vms: 1 # Number of VM instances assigned to the NAT gateway
     monthly_data_processed_gb: 5.0 # Monthly data processed (ingress and egress) by the NAT gateway in GB

--- a/regional/infra/infracost/us-east4-non-production.yml
+++ b/regional/infra/infracost/us-east4-non-production.yml
@@ -4,10 +4,6 @@
 # See https://infracost.io/usage-file/ for docs
 version: 0.1
 resource_type_default_usage:
-  ##
-  ## The following usage values apply to each resource of the given type, which is useful when you want to define defaults.
-  ## All values are commented-out, you can uncomment resource types and customize as needed.
-  ##
   google_compute_router_nat:
     assigned_vms: 1 # Number of VM instances assigned to the NAT gateway
     monthly_data_processed_gb: 10.0 # Monthly data processed (ingress and egress) by the NAT gateway in GB

--- a/regional/infra/infracost/us-east4-production.yml
+++ b/regional/infra/infracost/us-east4-production.yml
@@ -4,10 +4,6 @@
 # See https://infracost.io/usage-file/ for docs
 version: 0.1
 resource_type_default_usage:
-  ##
-  ## The following usage values apply to each resource of the given type, which is useful when you want to define defaults.
-  ## All values are commented-out, you can uncomment resource types and customize as needed.
-  ##
   google_compute_router_nat:
     assigned_vms: 3 # Number of VM instances assigned to the NAT gateway
     monthly_data_processed_gb: 25.0 # Monthly data processed (ingress and egress) by the NAT gateway in GB

--- a/regional/infra/infracost/us-east4-sandbox.yml
+++ b/regional/infra/infracost/us-east4-sandbox.yml
@@ -4,10 +4,6 @@
 # See https://infracost.io/usage-file/ for docs
 version: 0.1
 resource_type_default_usage:
-  ##
-  ## The following usage values apply to each resource of the given type, which is useful when you want to define defaults.
-  ## All values are commented-out, you can uncomment resource types and customize as needed.
-  ##
   google_compute_router_nat:
     assigned_vms: 1 # Number of VM instances assigned to the NAT gateway
     monthly_data_processed_gb: 5.0 # Monthly data processed (ingress and egress) by the NAT gateway in GB

--- a/regional/infra/main.tf
+++ b/regional/infra/main.tf
@@ -84,7 +84,7 @@ module "subnet" {
 resource "google_compute_subnetwork_iam_member" "cloud_services" {
   for_each = var.kubernetes_service_projects
 
-  member     = "serviceAccount:${each.key}@cloudservices.gserviceaccount.com"
+  member     = "serviceAccount:${each.value.number}@cloudservices.gserviceaccount.com"
   project    = local.global.project_id
   region     = var.region
   role       = "roles/compute.networkUser"
@@ -98,7 +98,7 @@ resource "google_compute_subnetwork_iam_member" "cloud_services" {
 resource "google_compute_subnetwork_iam_member" "container_engine" {
   for_each = var.kubernetes_service_projects
 
-  member     = "serviceAccount:service-${each.key}@container-engine-robot.iam.gserviceaccount.com"
+  member     = "serviceAccount:service-${each.value.number}@container-engine-robot.iam.gserviceaccount.com"
   project    = local.global.project_id
   region     = var.region
   role       = "roles/compute.networkUser"

--- a/regional/infra/main.tf
+++ b/regional/infra/main.tf
@@ -72,7 +72,7 @@ module "subnet" {
       ip_cidr_range = each.value.services_ip_cidr_range
     },
     {
-      range_name    = "service-k8s-pods-${var.region}"
+      range_name    = "services-k8s-pods-${var.region}"
       ip_cidr_range = each.value.pod_ip_cidr_range
     }
   ]

--- a/regional/infra/main.tf
+++ b/regional/infra/main.tf
@@ -27,6 +27,9 @@ data "terraform_remote_state" "global" {
   workspace = "global-${var.environment}"
 }
 
+# Google Cloud NAT Module (osinfra.io)
+# https://github.com/osinfra-io/terraform-google-cloud-nat
+
 module "cloud_nat" {
   source = "github.com/osinfra-io/terraform-google-cloud-nat//regional?ref=v0.1.0"
 
@@ -38,6 +41,9 @@ module "cloud_nat" {
     module.subnet
   ]
 }
+
+# Google Subnet Module (osinfra.io)
+# https://github.com/osinfra-io/terraform-google-subnet
 
 module "subnet" {
   source = "github.com/osinfra-io/terraform-google-subnet//regional?ref=v0.1.0"
@@ -69,5 +75,36 @@ module "subnet" {
       range_name    = "service-k8s-pods-${var.region}"
       ip_cidr_range = each.value.pod_ip_cidr_range
     }
+  ]
+}
+
+# Compute Subnetwork IAM Member Resource
+# https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_subnetwork_iam
+
+resource "google_compute_subnetwork_iam_member" "cloud_services" {
+  for_each = var.kubernetes_service_projects
+
+  member     = "serviceAccount:${each.key}@cloudservices.gserviceaccount.com"
+  project    = local.global.project_id
+  region     = var.region
+  role       = "roles/compute.networkUser"
+  subnetwork = "services-${var.region}"
+
+  depends_on = [
+    module.subnet
+  ]
+}
+
+resource "google_compute_subnetwork_iam_member" "container_engine" {
+  for_each = var.kubernetes_service_projects
+
+  member     = "serviceAccount:service-${each.key}@container-engine-robot.iam.gserviceaccount.com"
+  project    = local.global.project_id
+  region     = var.region
+  role       = "roles/compute.networkUser"
+  subnetwork = "services-${var.region}"
+
+  depends_on = [
+    module.subnet
   ]
 }

--- a/regional/infra/tfvars/us-east1-non-production.tfvars
+++ b/regional/infra/tfvars/us-east1-non-production.tfvars
@@ -1,4 +1,11 @@
-environment   = "non-production"
+environment = "non-production"
+
+kubernetes_service_projects = {
+  "plt-k8s-tf33-nonprod" = {
+    number = 1036446604184
+  }
+}
+
 region        = "us-east1"
 remote_bucket = "plt-lz-networking-3bfe-nonprod"
 

--- a/regional/infra/tfvars/us-east1-production.tfvars
+++ b/regional/infra/tfvars/us-east1-production.tfvars
@@ -1,4 +1,11 @@
-environment   = "production"
+environment = "production"
+
+kubernetes_service_projects = {
+  "plt-k8s-tf10-prod" = {
+    number = 502462287439
+  }
+}
+
 region        = "us-east1"
 remote_bucket = "plt-lz-networking-e194-prod"
 

--- a/regional/infra/tfvars/us-east1-sandbox.tfvars
+++ b/regional/infra/tfvars/us-east1-sandbox.tfvars
@@ -1,3 +1,9 @@
+kubernetes_service_projects = {
+  "plt-k8s-tfb4-sb" = {
+    number = 102727685445
+  }
+}
+
 region        = "us-east1"
 remote_bucket = "plt-lz-networking-2c8b-sb"
 

--- a/regional/infra/tfvars/us-east4-non-production.tfvars
+++ b/regional/infra/tfvars/us-east4-non-production.tfvars
@@ -1,4 +1,11 @@
-environment   = "non-production"
+environment = "non-production"
+
+kubernetes_service_projects = {
+  "plt-k8s-tf33-nonprod" = {
+    number = 1036446604184
+  }
+}
+
 region        = "us-east4"
 remote_bucket = "plt-lz-networking-3bfe-nonprod"
 

--- a/regional/infra/tfvars/us-east4-production.tfvars
+++ b/regional/infra/tfvars/us-east4-production.tfvars
@@ -1,4 +1,11 @@
-environment   = "production"
+environment = "production"
+
+kubernetes_service_projects = {
+  "plt-k8s-tf10-prod" = {
+    number = 502462287439
+  }
+}
+
 region        = "us-east4"
 remote_bucket = "plt-lz-networking-e194-prod"
 

--- a/regional/infra/tfvars/us-east4-sandbox.tfvars
+++ b/regional/infra/tfvars/us-east4-sandbox.tfvars
@@ -1,3 +1,9 @@
+kubernetes_service_projects = {
+  "plt-k8s-tfb4-sb" = {
+    number = 102727685445
+  }
+}
+
 region        = "us-east4"
 remote_bucket = "plt-lz-networking-2c8b-sb"
 

--- a/regional/infra/variables.tf
+++ b/regional/infra/variables.tf
@@ -5,9 +5,11 @@ variable "environment" {
 }
 
 variable "kubernetes_service_projects" {
-  description = "The set of Kubernetes service projects"
-  type        = set(string)
-  default     = []
+  description = "The map of Kubernetes service project IDs and numbers"
+  type = map(object({
+    number = optional(number)
+  }))
+  default = {}
 }
 
 variable "region" {

--- a/regional/infra/variables.tf
+++ b/regional/infra/variables.tf
@@ -4,6 +4,12 @@ variable "environment" {
   default     = "sandbox"
 }
 
+variable "kubernetes_service_projects" {
+  description = "The set of Kubernetes service projects"
+  type        = set(string)
+  default     = []
+}
+
 variable "region" {
   description = "The region for this subnetwork"
   type        = string


### PR DESCRIPTION
This pull request updates the versions of the `google` provider and the `terraform` provider. It also adds two new resources: `google_project_iam_member.container_engine_firewall_management` and `google_project_iam_member.container_engine_service_agent_user`. These resources manage IAM roles for Kubernetes clusters. Additionally, the `kubernetes_service_projects` variable has been added to allow specifying a set of Kubernetes service projects.