### PR TITLE
Allow service accounts to create DNS records

### DIFF
--- a/.github/ISSUE_TEMPLATE/add-update-shared-vpc-service-projects.yml
+++ b/.github/ISSUE_TEMPLATE/add-update-shared-vpc-service-projects.yml
@@ -15,7 +15,7 @@ body:
         [![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/osinfra-io/github-terraform-codespace)
     validations:
       required: true
-      
+
   - type: input
     id: email-address
     attributes:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,7 +21,7 @@ repos:
         verbose: false
 
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.83.6
+    rev: v1.85.0
     hooks:
       - id: terraform_fmt
 

--- a/global/infra/README.md
+++ b/global/infra/README.md
@@ -9,7 +9,7 @@ No requirements.
 
 | Name | Version |
 |------|---------|
-| <a name="provider_google"></a> [google](#provider\_google) | 5.8.0 |
+| <a name="provider_google"></a> [google](#provider\_google) | 5.10.0 |
 
 ## Modules
 
@@ -28,6 +28,7 @@ No requirements.
 | [google_compute_shared_vpc_service_project.this](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_shared_vpc_service_project) | resource |
 | [google_project_iam_member.container_engine_firewall_management](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
 | [google_project_iam_member.container_engine_service_agent_user](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
+| [google_project_iam_member.dns_records_admin](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
 | [google_service_networking_connection.this](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_networking_connection) | resource |
 
 ## Inputs
@@ -38,6 +39,7 @@ No requirements.
 | <a name="input_cis_2_2_logging_sink_project_id"></a> [cis\_2\_2\_logging\_sink\_project\_id](#input\_cis\_2\_2\_logging\_sink\_project\_id) | The CIS 2.2 logging sink benchmark project ID | `string` | n/a | yes |
 | <a name="input_datadog_api_key"></a> [datadog\_api\_key](#input\_datadog\_api\_key) | Datadog API key | `string` | n/a | yes |
 | <a name="input_datadog_app_key"></a> [datadog\_app\_key](#input\_datadog\_app\_key) | Datadog APP key | `string` | n/a | yes |
+| <a name="input_dns_records_admins"></a> [dns\_records\_admins](#input\_dns\_records\_admins) | The set of service accounts that can administer DNS records in this project | `set(string)` | `[]` | no |
 | <a name="input_environment"></a> [environment](#input\_environment) | The environment suffix for example: `sb` (Sandbox), `nonprod` (Non-Production), `prod` (Production) | `string` | `"sb"` | no |
 | <a name="input_folder_id"></a> [folder\_id](#input\_folder\_id) | The numeric ID of the folder this project should be created under. Only one of `org_id` or `folder_id` may be specified | `string` | n/a | yes |
 | <a name="input_kubernetes_service_projects"></a> [kubernetes\_service\_projects](#input\_kubernetes\_service\_projects) | The map of Kubernetes service project IDs and numbers | <pre>map(object({<br>    number = optional(number)<br>  }))</pre> | `{}` | no |

--- a/global/infra/main.tf
+++ b/global/infra/main.tf
@@ -169,6 +169,14 @@ resource "google_project_iam_member" "container_engine_service_agent_user" {
   role    = "roles/container.hostServiceAgentUser"
 }
 
+resource "google_project_iam_member" "dns_records_admin" {
+  for_each = var.dns_records_admins
+
+  member  = "serviceAccount:${each.key}"
+  project = module.project.project_id
+  role    = "organizations/163313809793/roles/dns.recordsAdmin"
+}
+
 # Service Networking Connection Resource
 # https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_networking_connection
 

--- a/global/infra/variables.tf
+++ b/global/infra/variables.tf
@@ -24,6 +24,12 @@ variable "datadog_app_key" {
   sensitive   = true
 }
 
+variable "dns_records_admins" {
+  description = "The set of service accounts that can administer DNS records in this project"
+  type        = set(string)
+  default     = []
+}
+
 variable "environment" {
   description = "The environment suffix for example: `sb` (Sandbox), `nonprod` (Non-Production), `prod` (Production)"
   type        = string


### PR DESCRIPTION
Fixes #101

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the `README.md` to reflect the new version of the `google` provider from `5.8.0` to `5.10.0`.
  - Added documentation for a new input variable `dns_records_admins` to manage DNS records administration.

- **New Features**
  - Introduced a new IAM role assignment feature for DNS record administration.

- **Refactor**
  - Updated pre-commit hooks to use a newer version `v1.85.0`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->