### PR TITLE
Fix production DNS records admin service account name

### DIFF
--- a/global/infra/tfvars/production.tfvars
+++ b/global/infra/tfvars/production.tfvars
@@ -2,7 +2,7 @@ environment                     = "prod"
 cis_2_2_logging_sink_project_id = "plt-lz-audit01-tf91-prod"
 
 dns_records_admins = [
-  "plt-k8s-github@ptl-lz-terraform-tf05-prod.iam.gserviceaccount.com"
+  "plt-k8s-github@ptl-lz-terraform-tf62-prod.iam.gserviceaccount.com"
 ]
 
 folder_id = "1033174574192"


### PR DESCRIPTION
This pull request fixes the production DNS records admin service account name by updating it to "plt-k8s-github@ptl-lz-terraform-tf62-prod.iam.gserviceaccount.com".

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the service account for DNS records management in the production environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->