### PR TITLE
Add Kubernetes ranges for `google-cloud-kubernetes` repository

### DIFF
--- a/regional/README.md
+++ b/regional/README.md
@@ -17,7 +17,7 @@ No requirements.
 | Name | Source | Version |
 |------|--------|---------|
 | <a name="module_cloud_nat"></a> [cloud\_nat](#module\_cloud\_nat) | github.com/osinfra-io/terraform-google-cloud-nat//regional | v0.1.0 |
-| <a name="module_subnet"></a> [subnet](#module\_subnet) | github.com/osinfra-io/terraform-google-subnet//regional | v0.1.0 |
+| <a name="module_subnets"></a> [subnets](#module\_subnets) | github.com/osinfra-io/terraform-google-subnet//regional | v0.1.1 |
 
 ## Resources
 
@@ -32,10 +32,9 @@ No requirements.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_environment"></a> [environment](#input\_environment) | The environment for example: `sandbox`, `non-production`, `production` | `string` | `"sandbox"` | no |
-| <a name="input_kubernetes_service_projects"></a> [kubernetes\_service\_projects](#input\_kubernetes\_service\_projects) | The map of Kubernetes service project IDs and numbers | <pre>map(object({<br>    number = optional(number)<br>  }))</pre> | `{}` | no |
 | <a name="input_region"></a> [region](#input\_region) | The region for this subnetwork | `string` | n/a | yes |
 | <a name="input_remote_bucket"></a> [remote\_bucket](#input\_remote\_bucket) | The remote bucket the `terraform_remote_state` data source retrieves the state from | `string` | n/a | yes |
-| <a name="input_subnets"></a> [subnets](#input\_subnets) | The map of subnets to create | <pre>map(object({<br>    ip_cidr_range          = string<br>    master_ip_cidr_range   = string<br>    pod_ip_cidr_range      = string<br>    services_ip_cidr_range = string<br>  }))</pre> | n/a | yes |
+| <a name="input_subnets"></a> [subnets](#input\_subnets) | The map of subnets to create | <pre>map(object({<br>    ip_cidr_range          = string<br>    service_project_number = string<br>    master_ip_cidr_range   = string<br>    pod_ip_cidr_range      = string<br>    services_ip_cidr_range = string<br>  }))</pre> | n/a | yes |
 
 ## Outputs
 

--- a/regional/tfvars/us-east1-non-production.tfvars
+++ b/regional/tfvars/us-east1-non-production.tfvars
@@ -1,19 +1,29 @@
-environment = "non-production"
-
-kubernetes_service_projects = {
-  "plt-k8s-tf33-nonprod" = {
-    number = 1036446604184
-  }
-}
-
+environment   = "non-production"
 region        = "us-east1"
 remote_bucket = "plt-lz-networking-3bfe-nonprod"
 
 subnets = {
-  "services" = {
-    ip_cidr_range          = "10.60.0.0/20"
-    master_ip_cidr_range   = "10.61.224.0/28"
-    pod_ip_cidr_range      = "10.0.0.0/14"
-    services_ip_cidr_range = "10.60.240.0/20"
+  "services-${var.region}-b" = {
+    ip_cidr_range          = "10.62.0.0/21"
+    master_ip_cidr_range   = "10.63.240.48/28"
+    pod_ip_cidr_range      = "10.0.0.0/15"
+    services_ip_cidr_range = "10.63.240.0/28"
+    service_project_number = "1036446604184" # plt-k8s-tf33-nonprod
+  }
+
+  "services-${var.region}-c" = {
+    ip_cidr_range          = "10.62.8.0/21"
+    master_ip_cidr_range   = "10.63.240.16/28"
+    pod_ip_cidr_range      = "10.2.0.0/15"
+    services_ip_cidr_range = "10.63.0.0/21"
+    service_project_number = "1036446604184" # plt-k8s-tf33-nonprod
+  }
+
+  "services-${var.region}-d" = {
+    ip_cidr_range          = "10.62.16.0/21"
+    master_ip_cidr_range   = "10.63.240.32/28"
+    pod_ip_cidr_range      = "10.4.0.0/15"
+    services_ip_cidr_range = "10.63.8.0/21"
+    service_project_number = "1036446604184" # plt-k8s-tf33-nonprod
   }
 }

--- a/regional/tfvars/us-east1-non-production.tfvars
+++ b/regional/tfvars/us-east1-non-production.tfvars
@@ -3,7 +3,7 @@ region        = "us-east1"
 remote_bucket = "plt-lz-networking-3bfe-nonprod"
 
 subnets = {
-  "services-${var.region}-b" = {
+  "services-us-east1-b" = {
     ip_cidr_range          = "10.62.0.0/21"
     master_ip_cidr_range   = "10.63.240.48/28"
     pod_ip_cidr_range      = "10.0.0.0/15"
@@ -11,7 +11,7 @@ subnets = {
     service_project_number = "1036446604184" # plt-k8s-tf33-nonprod
   }
 
-  "services-${var.region}-c" = {
+  "services-us-east1-c" = {
     ip_cidr_range          = "10.62.8.0/21"
     master_ip_cidr_range   = "10.63.240.16/28"
     pod_ip_cidr_range      = "10.2.0.0/15"
@@ -19,7 +19,7 @@ subnets = {
     service_project_number = "1036446604184" # plt-k8s-tf33-nonprod
   }
 
-  "services-${var.region}-d" = {
+  "services-us-east1-d" = {
     ip_cidr_range          = "10.62.16.0/21"
     master_ip_cidr_range   = "10.63.240.32/28"
     pod_ip_cidr_range      = "10.4.0.0/15"

--- a/regional/tfvars/us-east1-production.tfvars
+++ b/regional/tfvars/us-east1-production.tfvars
@@ -1,19 +1,29 @@
-environment = "production"
-
-kubernetes_service_projects = {
-  "plt-k8s-tf10-prod" = {
-    number = 502462287439
-  }
-}
-
+environment   = "production"
 region        = "us-east1"
 remote_bucket = "plt-lz-networking-e194-prod"
 
 subnets = {
-  "services" = {
-    ip_cidr_range          = "10.60.0.0/20"
-    master_ip_cidr_range   = "10.61.224.0/28"
-    pod_ip_cidr_range      = "10.0.0.0/14"
-    services_ip_cidr_range = "10.60.240.0/20"
+  "services-${var.region}-b" = {
+    ip_cidr_range          = "10.62.0.0/21"
+    master_ip_cidr_range   = "10.63.240.48/28"
+    pod_ip_cidr_range      = "10.0.0.0/15"
+    services_ip_cidr_range = "10.63.240.0/28"
+    service_project_number = "502462287439" # plt-k8s-tf10-prod
+  }
+
+  "services-${var.region}-c" = {
+    ip_cidr_range          = "10.62.8.0/21"
+    master_ip_cidr_range   = "10.63.240.16/28"
+    pod_ip_cidr_range      = "10.2.0.0/15"
+    services_ip_cidr_range = "10.63.0.0/21"
+    service_project_number = "502462287439" # plt-k8s-tf10-prod
+  }
+
+  "services-${var.region}-d" = {
+    ip_cidr_range          = "10.62.16.0/21"
+    master_ip_cidr_range   = "10.63.240.32/28"
+    pod_ip_cidr_range      = "10.4.0.0/15"
+    services_ip_cidr_range = "10.63.8.0/21"
+    service_project_number = "502462287439" # plt-k8s-tf10-prod
   }
 }

--- a/regional/tfvars/us-east1-production.tfvars
+++ b/regional/tfvars/us-east1-production.tfvars
@@ -3,7 +3,7 @@ region        = "us-east1"
 remote_bucket = "plt-lz-networking-e194-prod"
 
 subnets = {
-  "services-${var.region}-b" = {
+  "services-us-east1-b" = {
     ip_cidr_range          = "10.62.0.0/21"
     master_ip_cidr_range   = "10.63.240.48/28"
     pod_ip_cidr_range      = "10.0.0.0/15"
@@ -11,7 +11,7 @@ subnets = {
     service_project_number = "502462287439" # plt-k8s-tf10-prod
   }
 
-  "services-${var.region}-c" = {
+  "services-us-east1-c" = {
     ip_cidr_range          = "10.62.8.0/21"
     master_ip_cidr_range   = "10.63.240.16/28"
     pod_ip_cidr_range      = "10.2.0.0/15"
@@ -19,7 +19,7 @@ subnets = {
     service_project_number = "502462287439" # plt-k8s-tf10-prod
   }
 
-  "services-${var.region}-d" = {
+  "services-us-east1-d" = {
     ip_cidr_range          = "10.62.16.0/21"
     master_ip_cidr_range   = "10.63.240.32/28"
     pod_ip_cidr_range      = "10.4.0.0/15"

--- a/regional/tfvars/us-east1-sandbox.tfvars
+++ b/regional/tfvars/us-east1-sandbox.tfvars
@@ -1,17 +1,28 @@
-kubernetes_service_projects = {
-  "plt-k8s-tf39-sb" = {
-    number = 362793201562
-  }
-}
-
 region        = "us-east1"
 remote_bucket = "plt-lz-networking-2c8b-sb"
 
 subnets = {
-  "services" = {
-    ip_cidr_range          = "10.60.0.0/20"
-    master_ip_cidr_range   = "10.61.224.0/28"
-    pod_ip_cidr_range      = "10.0.0.0/14"
-    services_ip_cidr_range = "10.60.240.0/20"
+  "services-${var.region}-b" = {
+    ip_cidr_range          = "10.62.0.0/21"
+    master_ip_cidr_range   = "10.63.240.48/28"
+    pod_ip_cidr_range      = "10.0.0.0/15"
+    services_ip_cidr_range = "10.63.240.0/28"
+    service_project_number = "362793201562" # plt-k8s-tf39-sb
+  }
+
+  "services-${var.region}-c" = {
+    ip_cidr_range          = "10.62.8.0/21"
+    master_ip_cidr_range   = "10.63.240.16/28"
+    pod_ip_cidr_range      = "10.2.0.0/15"
+    services_ip_cidr_range = "10.63.0.0/21"
+    service_project_number = "362793201562" # plt-k8s-tf39-sb
+  }
+
+  "services-${var.region}-d" = {
+    ip_cidr_range          = "10.62.16.0/21"
+    master_ip_cidr_range   = "10.63.240.32/28"
+    pod_ip_cidr_range      = "10.4.0.0/15"
+    services_ip_cidr_range = "10.63.8.0/21"
+    service_project_number = "362793201562" # plt-k8s-tf39-sb
   }
 }

--- a/regional/tfvars/us-east1-sandbox.tfvars
+++ b/regional/tfvars/us-east1-sandbox.tfvars
@@ -2,7 +2,7 @@ region        = "us-east1"
 remote_bucket = "plt-lz-networking-2c8b-sb"
 
 subnets = {
-  "services-${var.region}-b" = {
+  "services-us-east1-b" = {
     ip_cidr_range          = "10.62.0.0/21"
     master_ip_cidr_range   = "10.63.240.48/28"
     pod_ip_cidr_range      = "10.0.0.0/15"
@@ -10,7 +10,7 @@ subnets = {
     service_project_number = "362793201562" # plt-k8s-tf39-sb
   }
 
-  "services-${var.region}-c" = {
+  "services-us-east1-c" = {
     ip_cidr_range          = "10.62.8.0/21"
     master_ip_cidr_range   = "10.63.240.16/28"
     pod_ip_cidr_range      = "10.2.0.0/15"
@@ -18,7 +18,7 @@ subnets = {
     service_project_number = "362793201562" # plt-k8s-tf39-sb
   }
 
-  "services-${var.region}-d" = {
+  "services-us-east1-d" = {
     ip_cidr_range          = "10.62.16.0/21"
     master_ip_cidr_range   = "10.63.240.32/28"
     pod_ip_cidr_range      = "10.4.0.0/15"

--- a/regional/tfvars/us-east4-non-production.tfvars
+++ b/regional/tfvars/us-east4-non-production.tfvars
@@ -1,19 +1,29 @@
-environment = "non-production"
-
-kubernetes_service_projects = {
-  "plt-k8s-tf33-nonprod" = {
-    number = 1036446604184
-  }
-}
-
+environment   = "non-production"
 region        = "us-east4"
 remote_bucket = "plt-lz-networking-3bfe-nonprod"
 
 subnets = {
-  "services" = {
-    ip_cidr_range          = "10.60.16.0/20"
-    master_ip_cidr_range   = "10.61.224.16/28"
-    pod_ip_cidr_range      = "10.4.0.0/14"
-    services_ip_cidr_range = "10.61.0.0/20"
+  "services-${var.region}-a" = {
+    ip_cidr_range          = "10.62.24.0/21"
+    master_ip_cidr_range   = "10.63.240.48/28"
+    pod_ip_cidr_range      = "10.6.0.0/15"
+    services_ip_cidr_range = "10.63.16.0/21"
+    service_project_number = "1036446604184" # plt-k8s-tf33-nonprod
+  }
+
+  "services-${var.region}-b" = {
+    ip_cidr_range          = "10.62.32.0/21"
+    master_ip_cidr_range   = "10.63.240.64/28"
+    pod_ip_cidr_range      = "10.8.0.0/15"
+    services_ip_cidr_range = "10.63.24.0/21"
+    service_project_number = "1036446604184" # plt-k8s-tf33-nonprod
+  }
+
+  "services-${var.region}-c" = {
+    ip_cidr_range          = "10.62.40.0/21"
+    master_ip_cidr_range   = "10.63.240.80/28"
+    pod_ip_cidr_range      = "10.10.0.0/15"
+    services_ip_cidr_range = "10.63.32.0/21"
+    service_project_number = "1036446604184" # plt-k8s-tf33-nonprod
   }
 }

--- a/regional/tfvars/us-east4-non-production.tfvars
+++ b/regional/tfvars/us-east4-non-production.tfvars
@@ -3,7 +3,7 @@ region        = "us-east4"
 remote_bucket = "plt-lz-networking-3bfe-nonprod"
 
 subnets = {
-  "services-${var.region}-a" = {
+  "services-us-east4-a" = {
     ip_cidr_range          = "10.62.24.0/21"
     master_ip_cidr_range   = "10.63.240.48/28"
     pod_ip_cidr_range      = "10.6.0.0/15"
@@ -11,7 +11,7 @@ subnets = {
     service_project_number = "1036446604184" # plt-k8s-tf33-nonprod
   }
 
-  "services-${var.region}-b" = {
+  "services-us-east4-b" = {
     ip_cidr_range          = "10.62.32.0/21"
     master_ip_cidr_range   = "10.63.240.64/28"
     pod_ip_cidr_range      = "10.8.0.0/15"
@@ -19,7 +19,7 @@ subnets = {
     service_project_number = "1036446604184" # plt-k8s-tf33-nonprod
   }
 
-  "services-${var.region}-c" = {
+  "services-us-east4-c" = {
     ip_cidr_range          = "10.62.40.0/21"
     master_ip_cidr_range   = "10.63.240.80/28"
     pod_ip_cidr_range      = "10.10.0.0/15"

--- a/regional/tfvars/us-east4-production.tfvars
+++ b/regional/tfvars/us-east4-production.tfvars
@@ -1,19 +1,29 @@
-environment = "production"
-
-kubernetes_service_projects = {
-  "plt-k8s-tf10-prod" = {
-    number = 502462287439
-  }
-}
-
+environment   = "production"
 region        = "us-east4"
 remote_bucket = "plt-lz-networking-e194-prod"
 
 subnets = {
-  "services" = {
-    ip_cidr_range          = "10.60.16.0/20"
-    master_ip_cidr_range   = "10.61.224.16/28"
-    pod_ip_cidr_range      = "10.4.0.0/14"
-    services_ip_cidr_range = "10.61.0.0/20"
+  "services-${var.region}-a" = {
+    ip_cidr_range          = "10.62.24.0/21"
+    master_ip_cidr_range   = "10.63.240.48/28"
+    pod_ip_cidr_range      = "10.6.0.0/15"
+    services_ip_cidr_range = "10.63.16.0/21"
+    service_project_number = "502462287439" # plt-k8s-tf10-prod
+  }
+
+  "services-${var.region}-b" = {
+    ip_cidr_range          = "10.62.32.0/21"
+    master_ip_cidr_range   = "10.63.240.64/28"
+    pod_ip_cidr_range      = "10.8.0.0/15"
+    services_ip_cidr_range = "10.63.24.0/21"
+    service_project_number = "502462287439" # plt-k8s-tf10-prod
+  }
+
+  "services-${var.region}-c" = {
+    ip_cidr_range          = "10.62.40.0/21"
+    master_ip_cidr_range   = "10.63.240.80/28"
+    pod_ip_cidr_range      = "10.10.0.0/15"
+    services_ip_cidr_range = "10.63.32.0/21"
+    service_project_number = "502462287439" # plt-k8s-tf10-prod
   }
 }

--- a/regional/tfvars/us-east4-production.tfvars
+++ b/regional/tfvars/us-east4-production.tfvars
@@ -3,7 +3,7 @@ region        = "us-east4"
 remote_bucket = "plt-lz-networking-e194-prod"
 
 subnets = {
-  "services-${var.region}-a" = {
+  "services-us-east4-a" = {
     ip_cidr_range          = "10.62.24.0/21"
     master_ip_cidr_range   = "10.63.240.48/28"
     pod_ip_cidr_range      = "10.6.0.0/15"
@@ -11,7 +11,7 @@ subnets = {
     service_project_number = "502462287439" # plt-k8s-tf10-prod
   }
 
-  "services-${var.region}-b" = {
+  "services-us-east4-b" = {
     ip_cidr_range          = "10.62.32.0/21"
     master_ip_cidr_range   = "10.63.240.64/28"
     pod_ip_cidr_range      = "10.8.0.0/15"
@@ -19,7 +19,7 @@ subnets = {
     service_project_number = "502462287439" # plt-k8s-tf10-prod
   }
 
-  "services-${var.region}-c" = {
+  "services-us-east4-c" = {
     ip_cidr_range          = "10.62.40.0/21"
     master_ip_cidr_range   = "10.63.240.80/28"
     pod_ip_cidr_range      = "10.10.0.0/15"

--- a/regional/tfvars/us-east4-sandbox.tfvars
+++ b/regional/tfvars/us-east4-sandbox.tfvars
@@ -2,7 +2,7 @@ region        = "us-east4"
 remote_bucket = "plt-lz-networking-2c8b-sb"
 
 subnets = {
-  "services-${var.region}-a" = {
+  "services-us-east4-a" = {
     ip_cidr_range          = "10.62.24.0/21"
     master_ip_cidr_range   = "10.63.240.48/28"
     pod_ip_cidr_range      = "10.6.0.0/15"
@@ -10,7 +10,7 @@ subnets = {
     service_project_number = "362793201562" # plt-k8s-tf39-sb
   }
 
-  "services-${var.region}-b" = {
+  "services-us-east4-b" = {
     ip_cidr_range          = "10.62.32.0/21"
     master_ip_cidr_range   = "10.63.240.64/28"
     pod_ip_cidr_range      = "10.8.0.0/15"
@@ -18,7 +18,7 @@ subnets = {
     service_project_number = "362793201562" # plt-k8s-tf39-sb
   }
 
-  "services-${var.region}-c" = {
+  "services-us-east4-c" = {
     ip_cidr_range          = "10.62.40.0/21"
     master_ip_cidr_range   = "10.63.240.80/28"
     pod_ip_cidr_range      = "10.10.0.0/15"

--- a/regional/tfvars/us-east4-sandbox.tfvars
+++ b/regional/tfvars/us-east4-sandbox.tfvars
@@ -1,17 +1,28 @@
-kubernetes_service_projects = {
-  "plt-k8s-tf39-sb" = {
-    number = 362793201562
-  }
-}
-
 region        = "us-east4"
 remote_bucket = "plt-lz-networking-2c8b-sb"
 
 subnets = {
-  "services" = {
-    ip_cidr_range          = "10.60.16.0/20"
-    master_ip_cidr_range   = "10.61.224.16/28"
-    pod_ip_cidr_range      = "10.4.0.0/14"
-    services_ip_cidr_range = "10.61.0.0/20"
+  "services-${var.region}-a" = {
+    ip_cidr_range          = "10.62.24.0/21"
+    master_ip_cidr_range   = "10.63.240.48/28"
+    pod_ip_cidr_range      = "10.6.0.0/15"
+    services_ip_cidr_range = "10.63.16.0/21"
+    service_project_number = "362793201562" # plt-k8s-tf39-sb
+  }
+
+  "services-${var.region}-b" = {
+    ip_cidr_range          = "10.62.32.0/21"
+    master_ip_cidr_range   = "10.63.240.64/28"
+    pod_ip_cidr_range      = "10.8.0.0/15"
+    services_ip_cidr_range = "10.63.24.0/21"
+    service_project_number = "362793201562" # plt-k8s-tf39-sb
+  }
+
+  "services-${var.region}-c" = {
+    ip_cidr_range          = "10.62.40.0/21"
+    master_ip_cidr_range   = "10.63.240.80/28"
+    pod_ip_cidr_range      = "10.10.0.0/15"
+    services_ip_cidr_range = "10.63.32.0/21"
+    service_project_number = "362793201562" # plt-k8s-tf39-sb
   }
 }

--- a/regional/variables.tf
+++ b/regional/variables.tf
@@ -4,14 +4,6 @@ variable "environment" {
   default     = "sandbox"
 }
 
-variable "kubernetes_service_projects" {
-  description = "The map of Kubernetes service project IDs and numbers"
-  type = map(object({
-    number = optional(number)
-  }))
-  default = {}
-}
-
 variable "region" {
   description = "The region for this subnetwork"
   type        = string
@@ -26,6 +18,7 @@ variable "subnets" {
   description = "The map of subnets to create"
   type = map(object({
     ip_cidr_range          = string
+    service_project_number = string
     master_ip_cidr_range   = string
     pod_ip_cidr_range      = string
     services_ip_cidr_range = string


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced region-specific subnet configurations across various environments (non-production, production, sandbox) with unique IP ranges and master configurations.
	- Added `service_project_number` field to subnet configurations to enhance project management and identification.

- **Refactor**
	- Renamed `module_subnet` to `module_subnets` and updated related attributes to align with the new naming convention.
	- Adjusted subnet configurations to be more region-specific, providing distinct IP ranges and configurations for enhanced network management.

- **Documentation**
	- Updated documentation to reflect changes in subnet naming and the addition of the `service_project_number` field.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->